### PR TITLE
feat(plugin-compiler-web): .json 文件支持条件编译

### DIFF
--- a/packages/plugin-compiler-web/src/compiler/core/js/index.ts
+++ b/packages/plugin-compiler-web/src/compiler/core/js/index.ts
@@ -1,5 +1,6 @@
 import * as babel from '@babel/core'
 import generate from '@babel/generator'
+import path from 'path'
 import { WEB_RUNTIMES } from '../../../constants'
 import { defCondition, isEndIf, isIfDef } from '../../utils/comment'
 import { getAxmlResourcePath } from '../../utils/file-utils'
@@ -7,9 +8,15 @@ import { BuildOptions } from '../option'
 import ComponentPlugin from './component'
 
 export default function (content, options: BuildOptions) {
-  const { isAtomicMode, templateFilePath, name } = options
+  const {
+    isAtomicMode,
+    templateFilePath,
+    hasAppConfig,
+    appConfigPath,
+    resourcePath,
+    configFilePath
+  } = options
   const config = options.config || {}
-
   if (templateFilePath) {
     content = `
     ${
@@ -20,9 +27,19 @@ export default function (content, options: BuildOptions) {
     export default $rm.${
       config.component ? 'Component' : 'Page'
     }($componentInfo$, $rm.mergeConfig(${
-      options.hasAppConfig ? 'require("@/app.json")' : '{}'
+      hasAppConfig
+        ? `require('./${path.relative(
+            path.dirname(resourcePath),
+            appConfigPath
+          )}')`
+        : '{}'
     }, ${
-      Object.keys(config).length === 0 ? '{}' : `require("${`./${name}.json`}")`
+      Object.keys(config).length === 0
+        ? '{}'
+        : `require('./${path.relative(
+            path.dirname(templateFilePath),
+            configFilePath
+          )}')`
     }))
     `
   }

--- a/packages/plugin-compiler-web/src/compiler/core/js/index.ts
+++ b/packages/plugin-compiler-web/src/compiler/core/js/index.ts
@@ -1,6 +1,6 @@
 import * as babel from '@babel/core'
 import generate from '@babel/generator'
-import path from 'path'
+import { getRelativePath } from '@morjs/utils'
 import { WEB_RUNTIMES } from '../../../constants'
 import { defCondition, isEndIf, isIfDef } from '../../utils/comment'
 import { getAxmlResourcePath } from '../../utils/file-utils'
@@ -28,18 +28,10 @@ export default function (content, options: BuildOptions) {
       config.component ? 'Component' : 'Page'
     }($componentInfo$, $rm.mergeConfig(${
       hasAppConfig
-        ? `require('./${path.relative(
-            path.dirname(resourcePath),
-            appConfigPath
-          )}')`
+        ? `require('${getRelativePath(resourcePath, appConfigPath)}')`
         : '{}'
     }, ${
-      Object.keys(config).length === 0
-        ? '{}'
-        : `require('./${path.relative(
-            path.dirname(templateFilePath),
-            configFilePath
-          )}')`
+      Object.keys(config).length === 0 ? '{}' : `require('${configFilePath}')`
     }))
     `
   }

--- a/packages/plugin-compiler-web/src/compiler/core/option.ts
+++ b/packages/plugin-compiler-web/src/compiler/core/option.ts
@@ -31,6 +31,7 @@ export interface BuildOptions {
   config: ComponentConfig
   appConfig: AppConfig
   hasAppConfig?: boolean // 是否配置了app.json 文件
+  appConfigPath?: string // app.json 的路径
   isAtomicMode?: boolean // 是否输出组件
   name: string //文件名称，不包含后缀
   resourcePath: string //資源文件路徑,

--- a/packages/plugin-compiler-web/src/loaders/builder.ts
+++ b/packages/plugin-compiler-web/src/loaders/builder.ts
@@ -149,6 +149,7 @@ export class LoaderBuilder {
     if (appStyleFilePath) {
       appStyleFilePath = path.basename(appStyleFilePath)
     }
+    const appConfigPath = this.getAppConfigFilePath()
 
     return {
       ...opts,
@@ -156,7 +157,8 @@ export class LoaderBuilder {
       name: this.getResourceName(),
       config: await this.loadRelatedConfig(),
       appConfig,
-      hasAppConfig: !!this.getAppConfigFilePath(),
+      hasAppConfig: !!appConfigPath,
+      appConfigPath,
       resourcePath: this.loader.resourcePath,
       rootPath: this.userConfig.srcPath,
       globalComponentsConfig: opts.globalComponentsConfig,

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,5 +1,5 @@
 import consolePng from 'console-png'
-import { delimiter, dirname, resolve } from 'path'
+import path, { delimiter, dirname, resolve } from 'path'
 import qrImage from 'qr-image'
 import slash from 'slash'
 import { asArray, esbuild, logger } from 'takin'
@@ -225,4 +225,24 @@ export async function isCommonJsModule(
   } else {
     return isCommonJs
   }
+}
+
+/**
+ * 返回从 from 到 to 的相对路径
+ * @param from - 参考路径
+ * @param to - 需要转换的路径
+ * @returns 相对路径
+ */
+export function getRelativePath(from, to) {
+  // 获取到文件的目录，不能直接以文件路径做对比，否则获取到到的结果会多一层级
+  const fromDirPath = path.dirname(from)
+  const relativePath = path.relative(fromDirPath, to)
+  const prefix =
+    relativePath.startsWith('./') || relativePath.startsWith('../')
+      ? relativePath.startsWith('.\\') || relativePath.startsWith('..\\')
+        ? ''
+        : '.\\'
+      : './'
+
+  return slash(prefix + relativePath)
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,5 +1,5 @@
 import consolePng from 'console-png'
-import path, { delimiter, dirname, resolve } from 'path'
+import { delimiter, dirname, relative, resolve } from 'path'
 import qrImage from 'qr-image'
 import slash from 'slash'
 import { asArray, esbuild, logger } from 'takin'
@@ -231,12 +231,13 @@ export async function isCommonJsModule(
  * 返回从 from 到 to 的相对路径
  * @param from - 参考路径
  * @param to - 需要转换的路径
+ * @param forcePosix - 是否使用 POSIX 格式路径
  * @returns 相对路径
  */
-export function getRelativePath(from, to) {
+export function getRelativePath(from, to, forcePosix = true) {
   // 获取到文件的目录，不能直接以文件路径做对比，否则获取到到的结果会多一层级
-  const fromDirPath = path.dirname(from)
-  const relativePath = path.relative(fromDirPath, to)
+  const fromDirPath = dirname(from)
+  const relativePath = relative(fromDirPath, to)
   const prefix =
     relativePath.startsWith('./') || relativePath.startsWith('../')
       ? relativePath.startsWith('.\\') || relativePath.startsWith('..\\')
@@ -244,5 +245,6 @@ export function getRelativePath(from, to) {
         : '.\\'
       : './'
 
+  if (!forcePosix) return prefix + relativePath
   return slash(prefix + relativePath)
 }


### PR DESCRIPTION
before: 通过 require('xx.json') 的方式获取配置文件，导致 .json 的文件无法使用 mor 上层提供的条件编译功能
after: 直接使用 mor 使用条件编译之后获取到的配置