### PR TITLE
feat： 全局文件名称常量方法支持配置后缀用于规避文件冲突

### DIFF
--- a/packages/plugin-compiler-alipay/src/plugins/TemplateParserPlugin.ts
+++ b/packages/plugin-compiler-alipay/src/plugins/TemplateParserPlugin.ts
@@ -24,7 +24,7 @@ export default class AlipayCompilerTemplateParserPlugin implements Plugin {
     })
 
     runner.hooks.beforeRun.tap(this.name, () => {
-      const { sourceType, target } = runner.userConfig
+      const { sourceType, target, globalNameSurfix } = runner.userConfig
 
       // 仅当 模版文件 是 支付宝 源码 且 编译目标不是 支付宝小程序 时执行该插件
       if (sourceType !== SourceTypes.alipay) return
@@ -46,7 +46,7 @@ export default class AlipayCompilerTemplateParserPlugin implements Plugin {
       if (!sjsModuleAttrName) return
       if (!sjsSrcAttrName) return
 
-      const sjsFileName = `${MOR_HELPER_FILE()}${sjsFileType}`
+      const sjsFileName = `${MOR_HELPER_FILE(globalNameSurfix)}${sjsFileType}`
       const sjsHelperName = 'morSjs'
       // 判断是否存在 morSjs.xxx( 方法调用
       const sjsHelperFnRegExp = new RegExp(`${sjsHelperName}\\.[a-zA-Z]+\\(`)

--- a/packages/plugin-compiler-web/src/plugins/bundleOptimizationPlugin.ts
+++ b/packages/plugin-compiler-web/src/plugins/bundleOptimizationPlugin.ts
@@ -1,5 +1,5 @@
 import {
-  mor,
+  MOR_RUNTIME_WEB_FILE,
   MOR_VENDOR_FILE,
   Plugin,
   Runner,
@@ -15,7 +15,9 @@ export class BundleOptimizationPlugin implements Plugin {
   constructor(public wrapper: WebpackWrapper) {}
   apply(runner: Runner<any>) {
     this.removeMiniFileGenerator()
-    this.setupDefaultOptimization()
+    this.setupDefaultOptimization(
+      runner?.userConfig?.globalNameSurfix as string
+    )
     this.supportSjsExtensionAlias(runner?.userConfig?.sourceType as string)
   }
 
@@ -54,7 +56,7 @@ export class BundleOptimizationPlugin implements Plugin {
   /**
    * 设置默认的打包优化
    */
-  setupDefaultOptimization() {
+  setupDefaultOptimization(globalNameSurfix?: string) {
     // 默认优化
     this.wrapper.chain.optimization.splitChunks({
       chunks: 'all',
@@ -70,14 +72,14 @@ export class BundleOptimizationPlugin implements Plugin {
         },
         // runtime-web 运行时
         web: {
-          name: `${mor.name}.w`,
+          name: MOR_RUNTIME_WEB_FILE(globalNameSurfix),
           test: /(@morjs[\\/]|@ali[\\/]openmor-)runtime-web/,
           priority: 3
         },
 
         // 其他 node_modules
         vendors: {
-          name: MOR_VENDOR_FILE(),
+          name: MOR_VENDOR_FILE(globalNameSurfix),
           test: /\/(node_modules|npm_components|mock)\//,
           priority: 2
         }

--- a/packages/plugin-compiler-web/src/plugins/generateJSXEntryPlugin.ts
+++ b/packages/plugin-compiler-web/src/plugins/generateJSXEntryPlugin.ts
@@ -257,8 +257,9 @@ export class GenerateJSXEntryPlugin implements Plugin {
     const userConfig = runner.userConfig as WebCompilerUserConfig & {
       compileType: string
       srcPath: string
+      globalNameSurfix?: string
     }
-    const { web, compileType, srcPath } = userConfig
+    const { web, compileType, srcPath, globalNameSurfix } = userConfig
 
     const webRuntimeConfig: WebRuntimeConfig = { pages: [] }
 
@@ -392,6 +393,6 @@ export class GenerateJSXEntryPlugin implements Plugin {
       wrapper.fs.mem.writeFileSync(pagePath, pageContent)
     })
 
-    return { [MOR_GLOBAL_FILE()]: mainEntryPath }
+    return { [MOR_GLOBAL_FILE(globalNameSurfix)]: mainEntryPath }
   }
 }

--- a/packages/plugin-compiler/src/constants.ts
+++ b/packages/plugin-compiler/src/constants.ts
@@ -899,6 +899,10 @@ export const CompilerUserConfigSchema = z.object({
   cache: z.boolean().optional(),
   globalObject: z.string().optional(),
   /**
+   * 用于配置全局文件的后缀，避免冲突，以及 globalChunkLoading 的后缀添加
+   */
+  globalNameSurfix: z.string().optional(),
+  /**
    * 自定义 entries
    * 1. 用于自定义 app.json / subpackage.json / plugin.json 等入口文件
    * 2. 用于配置 额外需要生成的入口文件，如某个期望在 bundle 后依然能保持正确的路径的文件

--- a/packages/plugin-compiler/src/plugins/injectGetAppPlugin.ts
+++ b/packages/plugin-compiler/src/plugins/injectGetAppPlugin.ts
@@ -121,6 +121,7 @@ export class InjectGetAppPlugin implements Plugin {
       target,
       compileMode,
       compileType,
+      globalNameSurfix,
       compilerOptions: { module: defaultModuleKind }
     } = userConfig
 
@@ -138,11 +139,11 @@ export class InjectGetAppPlugin implements Plugin {
     const moduleKind = userConfig['originalCompilerModule'] || defaultModuleKind
 
     // 插件或分包的模拟 app 名称
-    const MOR_APP_ENTRY_NAME = MOR_APP_FILE()
+    const MOR_APP_ENTRY_NAME = MOR_APP_FILE(globalNameSurfix)
 
     // 添加模拟的 global 文件
     entryBuilder.setEntrySource(
-      MOR_GLOBAL_FILE() + '.js',
+      MOR_GLOBAL_FILE(globalNameSurfix) + '.js',
       generateGlobalScript(moduleKind, globalObject),
       'additional'
     )
@@ -162,7 +163,7 @@ export class InjectGetAppPlugin implements Plugin {
             return new webpack.sources.ConcatSource(
               makeImportClause(
                 moduleKind,
-                `./${MOR_GLOBAL_FILE()}.js`,
+                `./${MOR_GLOBAL_FILE(globalNameSurfix)}.js`,
                 'morGlobal'
               ),
               source
@@ -170,11 +171,11 @@ export class InjectGetAppPlugin implements Plugin {
           }
         }
 
-        if (chunk.name === MOR_RUNTIME_FILE()) {
+        if (chunk.name === MOR_RUNTIME_FILE(globalNameSurfix)) {
           return new webpack.sources.ConcatSource(
             makeImportClause(
               moduleKind,
-              `./${MOR_GLOBAL_FILE()}.js`,
+              `./${MOR_GLOBAL_FILE(globalNameSurfix)}.js`,
               'morGlobal'
             ),
             source

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -224,9 +224,11 @@ export const MOR_SHARED_FILE = function (surfix?: string) {
 
 /**
  * app.json 的 js 文件, 主要用于集成研发场景下对 app.json 的引用做替换
+ * 不需要支持 surfix，原因：全局只有一个 app.json 配置文件，也只需要一个 mor.p.js 文件，
+ * 用于确保集成时各个分包更新的 mor.p.js 始终是同一个文件
  */
-export const MOR_COMPOSED_APP_FILE = function (surfix?: string) {
-  return mor.name + '.' + 'p' + (surfix ? '.' + surfix : '')
+export const MOR_COMPOSED_APP_FILE = function () {
+  return mor.name + '.' + 'p'
 }
 
 /**

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -169,62 +169,69 @@ export enum EntryPriority {
 /**
  * 全局文件 name.g
  */
-export const MOR_GLOBAL_FILE = function () {
-  return mor.name + '.' + 'g'
+export const MOR_GLOBAL_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'g' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 运行时文件 name.r
  */
-export const MOR_RUNTIME_FILE = function () {
-  return mor.name + '.' + 'r'
+export const MOR_RUNTIME_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'r' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 初始化文件 name.i
  */
-export const MOR_INIT_FILE = function () {
-  return mor.name + '.' + 'i'
+export const MOR_INIT_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'i' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * vendors 文件 name.v, 用于存放 node_modules 代码
  */
-export const MOR_VENDOR_FILE = function () {
-  return mor.name + '.' + 'v'
+export const MOR_VENDOR_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'v' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 通用脚本文件 name.c 用于存放 公共 js 代码
  */
-export const MOR_COMMON_FILE = function () {
-  return mor.name + '.' + 'c'
+export const MOR_COMMON_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'c' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 模拟入口文件 name.a 用于存放 插件或分包的模拟 app 入口代码
  */
-export const MOR_APP_FILE = function () {
-  return mor.name + '.' + 'a'
+export const MOR_APP_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'a' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 辅助文件 name.h 用于存放一些辅助方法, 如 mor.h.sjs
  */
-export const MOR_HELPER_FILE = function () {
-  return mor.name + '.' + 'h'
+export const MOR_HELPER_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'h' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * 共享文件 name.s 用于存放一些共享 node_modules 引用, 如 mor.s.js
  */
-export const MOR_SHARED_FILE = function () {
-  return mor.name + '.' + 's'
+export const MOR_SHARED_FILE = function (surfix?: string) {
+  return mor.name + '.' + 's' + (surfix ? '.' + surfix : '')
 }
 
 /**
  * app.json 的 js 文件, 主要用于集成研发场景下对 app.json 的引用做替换
  */
-export const MOR_COMPOSED_APP_FILE = function () {
-  return mor.name + '.' + 'p'
+export const MOR_COMPOSED_APP_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'p' + (surfix ? '.' + surfix : '')
+}
+
+/**
+ * Web 转端运行时 js 文件，主要用于默认的转 web 内置运行时 bundle 文件名称
+ */
+export const MOR_RUNTIME_WEB_FILE = function (surfix?: string) {
+  return mor.name + '.' + 'w' + (surfix ? '.' + surfix : '')
 }


### PR DESCRIPTION
- feat(plugin-compiler): 完善自定义入口配置文件的解析逻辑，允许指定为非源码目录的文件
- feat(plugin-compiler-web): 优化 Web 编译的 bundle 文件生成名称
- feat(plugin-compiler-alipay): 优化 sjs 帮助文件的名称生成逻辑
- feat(plugin-compiler): 优化编译相关全局文件名称生成逻辑，允许配置后缀名以避免冲突
- feat(utils): 全局文件名称常量方法支持配置后缀用于规避文件冲突