### PR TITLE
fix(plugin-compiler): 修复 autoInjectRuntime.api 未自动转换为 enhanced 引发的 ts 类型报错

### DIFF
--- a/packages/plugin-compiler/src/config.ts
+++ b/packages/plugin-compiler/src/config.ts
@@ -447,7 +447,10 @@ export function applyDefaults(
       userConfig.autoInjectRuntime.component =
         userConfig.autoInjectRuntime.component ?? true
       userConfig.autoInjectRuntime.api =
-        userConfig.autoInjectRuntime.api ?? GlobalObjectTransformTypes.enhanced
+        userConfig.autoInjectRuntime.api === true
+          ? GlobalObjectTransformTypes.enhanced
+          : userConfig.autoInjectRuntime.api ??
+            GlobalObjectTransformTypes.enhanced
       if (sourceType !== SourceTypes.alipay) {
         userConfig.autoInjectRuntime.behavior =
           userConfig.autoInjectRuntime.behavior ?? true


### PR DESCRIPTION
#81 