### PR TITLE
fix(runtime-web): disable-scroll 切换为 false 时容器仍然不可滚动

### DIFF
--- a/packages/runtime-web/src/components/src/views/view/index.ts
+++ b/packages/runtime-web/src/components/src/views/view/index.ts
@@ -125,13 +125,13 @@ export default class View extends BaseElement {
 
   preventScroll() {
     // 组织元素上的滚动事件
-    this.addEventListener('touchmove', preventHandle)
-    this.addEventListener('scroll', preventHandle)
+    this.shadowRoot.addEventListener('touchmove', preventHandle, false)
+    this.shadowRoot.addEventListener('scroll', preventHandle, false)
   }
 
   releaseScroll() {
-    this.removeEventListener('touchmove', preventHandle)
-    this.removeEventListener('scroll', preventHandle)
+    this.shadowRoot.removeEventListener('touchmove', preventHandle, false)
+    this.shadowRoot.removeEventListener('scroll', preventHandle, false)
   }
 
   attributeChangedCallback(name, oldVal, newVal) {


### PR DESCRIPTION
问题：disable-scroll 切换为 false 时容器仍然不可滚动。

原因：view 继承自 baseElement，baseElement 中提供了 addEventListener 方法，所以 view 中调用 addEventListener 注册的事件，无法通过 removeEventListener 取消。

解决：为了避免调用到父级自定义逻辑的 addEventListener，将事件的注册和解绑操作放到 shadowRoot 上去。