### PR TITLE
fix(runtime-mini): 支持 catch 前缀回调

### DIFF
--- a/packages/runtime-mini/src/alipay/componentToAlipay.ts
+++ b/packages/runtime-mini/src/alipay/componentToAlipay.ts
@@ -167,7 +167,7 @@ function injectEventSupport(options: Record<string, any>) {
       : {}
 
     // 支付宝组件传递函数时 必须以 on 开头并且 on 后的第一个字母必须大写（微信必须全小写）
-    if (typeof this.props[`on${name}`] === 'function') {
+    const callEventHandler = (eventName: string)=> {
       const currentTarget = eventObj.currentTarget || {}
       const target = eventObj.target || {}
       const e = {
@@ -179,7 +179,8 @@ function injectEventSupport(options: Record<string, any>) {
           },
           target: {
             ...target,
-            dataset: { ...(target.dataset || {}), ...dataset }
+            dataset: { ...(target.dataset || {}), ...dataset },
+            id: this.props.id
           }
         },
         type: name
@@ -195,7 +196,12 @@ function injectEventSupport(options: Record<string, any>) {
         e.detail = params
       }
 
-      this.props[`on${name}`](e, opts)
+      this.props[eventName](e, opts)
+    }
+    if (typeof this.props[`on${name}`] === 'function') {
+      callEventHandler(`on${name}`)
+    } else if (typeof this.props[`catch${name}`] === 'function') {
+      callEventHandler(`catch${name}`)
     }
   }
 


### PR DESCRIPTION
## 修复原因

微信小程序下，当使用 catch 前缀时：
```html
<some-component catch:change="handleAgreeChange"/>
```
代码会被转换为
```html
<some-copmonent catchChange="handleAgreeChange" ref="$morSaveRef" morTagId="isAgree">
```

目前组件内的 triggerEvent 仅会触发 `on` 前缀的回调