### PR TITLE
feat(plugin-compiler): 类名压缩时支持微信特殊类名用法

### DIFF
--- a/packages/plugin-compiler/src/experiments/cssClassnameCompress.ts
+++ b/packages/plugin-compiler/src/experiments/cssClassnameCompress.ts
@@ -265,7 +265,6 @@ export class CSSClassNameCompressPlugin implements Plugin {
             newNames.push(prefix ? prefix + shortClassName : shortClassName)
           })
 
-          console.log('++names', names, newNames)
           // 替换属性值
           node.attrs[attr] = newNames.join(' ')
         }


### PR DESCRIPTION
微信场景支持使用 ~ 或者 ^ 使用父组件的样式（https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/wxml-wxss.html）