### PR TITLE
fix(runtime-web): 修复 PageComponent 获取url参数缺失的问题

### DIFF
--- a/packages/runtime-web/src/runtime/public/page.tsx
+++ b/packages/runtime-web/src/runtime/public/page.tsx
@@ -16,10 +16,9 @@ export function getQueryParams(url) {
 
   const params = {}
   if (url.indexOf('?') !== -1) {
-    const str = url.substr(url.indexOf('?') + 1)
-    const strs = str.split('&')
-    for (let i = 0; i < strs.length; i++) {
-      params[strs[i].split('=')[0]] = decodeURIComponent(strs[i].split('=')[1])
+    const searchParams = new URLSearchParams(url)
+    for(const [key, value] of searchParams.entries()){
+      params[key] = decodeURIComponent(value)
     }
   }
   return params


### PR DESCRIPTION
如果url参数里面有?会导致错误的截取参数 因此需要该修复